### PR TITLE
Fix SGX library when enabling Ed25519 support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,6 +355,9 @@ fn apply_patches(features: FeatureFlags, inner: &Path) {
 
     if features.intersects(FeatureFlags::ED25519) {
         sgx_files.push("$(WOLFSSL_ROOT)/wolfcrypt/src/ed25519.c");
+        sgx_files.push("$(WOLFSSL_ROOT)/wolfcrypt/src/fe_operations.c");
+        sgx_files.push("$(WOLFSSL_ROOT)/wolfcrypt/src/ge_operations.c");
+        sgx_defines.push("    #define WOLFSSL_SHA512");
         sgx_defines.push("    #define HAVE_ED25519");
     }
 


### PR DESCRIPTION
This includes the following changes to address issues when trying to
link wolfSSL/wolfCrypt with Ed25519 enabled into an SGX library:

- Add fe_operations.c and ge_operations.c to the source list.
- Define "WOLFSSL_SHA512" so that SHA512 functions can be resolved.