### PR TITLE
Fix SGX source patching for define-only changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,9 @@ fn apply_patches(features: FeatureFlags, inner: &Path) {
                 &format!("Wolfssl_C_Files :={} ", sgx_files.join(" "),),
             );
         });
+    }
+
+    if !sgx_defines.is_empty() {
         do_patch(inner.join("wolfssl/wolfcrypt/settings.h"), |buf| {
             *buf = buf.replace(
                 "#endif /* WOLFSSL_SGX */",


### PR DESCRIPTION
The source file patching process performed when enabling features for
SGX builds incorrectly ignores "#define" changes to wolfcrypt/settings.h
if there are no changes to the source file list. This prevents TLS 1.3
support from working in SGX builds unless Curve25519 or Ed25519 support
is enabled as well. This commit fixes the issue, applying "#define"
patches if needed regardless of whether additional source files need to
be compiled.